### PR TITLE
flags usage on -help

### DIFF
--- a/cmd/jid/jid.go
+++ b/cmd/jid/jid.go
@@ -27,6 +27,7 @@ func main() {
 	flag.Parse()
 
 	if help {
+		flag.Usage()
 		fmt.Println(getHelpString())
 		os.Exit(0)
 	}


### PR DESCRIPTION
When using `-help` it appear the help when you are in filter mode, but doesn't show the flags you can use.

This PR solves that.