### PR TITLE
Add &field candidate completion for JMESPath function arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ChangeLog
 =======
 
-### 1.2.0 - Apr 2026
+### 1.1.2 - Apr 2026
 
 Features:
 * `&field` candidate completion inside function arguments: when a function template

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,19 @@
 ChangeLog
 =======
 
+### 1.2.0 - Apr 2026
+
+Features:
+* `&field` candidate completion inside function arguments: when a function template
+  inserts a `&field` placeholder (e.g. `sort_by(@, &field)`), field candidates from
+  the base array are automatically shown so the user can Tab-cycle or type to filter
+* Placeholder text is removed immediately on entering candidate mode; cursor is placed
+  between `&` and `)` for clean inline editing
+* `Ctrl+W` now treats `&field)` as one deletion unit and stops at `&`, preserving it
+  (e.g. `max_by(@, &base_stat)` → `max_by(@, &`)
+* Suppressed misleading green hint in `&partial` mode (hint appeared after `)`)
+* Cursor stays between `&` and `)` while Tab-cycling field candidates
+
 ### 1.1.1 - Mar 28 2026
 
 Features:

--- a/README.md
+++ b/README.md
@@ -315,9 +315,27 @@ When a function candidate is confirmed, the arguments are automatically filled i
 | `join` | `join('', @)` | inside `''` (separator) |
 | `sort_by` | `sort_by(@, &field)` | on `field` placeholder |
 | `max_by` | `max_by(@, &field)` | on `field` placeholder |
+| `min_by` | `min_by(@, &field)` | on `field` placeholder |
 | `map` | `map(&expr, @)` | on `expr` placeholder |
 
-Placeholder text is shown in blue. Typing any character replaces the entire placeholder.
+Placeholder text is shown in cyan. Typing any character replaces the entire placeholder.
+
+#### `&field` Candidate Completion
+
+For functions that take a `&field` argument (`sort_by`, `max_by`, `min_by`, `map`),
+jid automatically shows the available field names from the base array as soon as the
+`&field` template is inserted:
+
+```
+.stats | sort_by(@, &field)   →  field names shown: base_stat  effort  stat
+.stats | sort_by(@, &b        →  filtered: base_stat
+.stats | sort_by(@, &base_stat)  →  confirmed; expression evaluates normally
+```
+
+- **Tab / Shift+Tab** cycles through field candidates; cursor stays between `&` and `)`
+- **Typing** filters candidates by the partial name after `&`
+- **Enter** or **Tab** (when only one candidate) confirms the selection
+- **Ctrl+W** deletes the field name but keeps `&` (e.g. `&base_stat)` → `&`)
 
 ### Wildcard Projection Navigation
 
@@ -340,4 +358,11 @@ After a wildcard expression like `.game_indices[*]`, jid shows the field names o
 .[3] | to_array(@)[0]     →(Ctrl+W)→  .[3] | to_array(@)
 .[3] | to_array(@)        →(Ctrl+W)→  .[3] |
 .[3] |                    →(Ctrl+W)→  .[3]
+```
+
+Inside a function call, the `&field` argument is treated as one unit and `&` is preserved:
+
+```
+.stats | max_by(@, &base_stat)  →(Ctrl+W)→  .stats | max_by(@, &
+.stats | max_by(@, &            →(Ctrl+W)→  .stats |
 ```

--- a/cmd/jid/jid.go
+++ b/cmd/jid/jid.go
@@ -82,49 +82,78 @@ $ jid < file.json
 ============ With a JSON filter mode =============
 
 TAB / CTRL-I
-  Show available items and choice them
+  Show available candidates and cycle forward.
+  In JMESPath pipe mode, shows field or function candidates.
+  Confirms immediately when only one candidate matches.
+
+Shift-TAB
+  Cycle candidates backward.
+  Outside candidate mode: decrement the last array index.
+
+Enter
+  Exit jid and print the current result.
+  If a candidate list is open, confirm the selected candidate instead.
+  Set exit_on_enter = false in config.toml to disable accidental exit.
 
 CTRL-W
-  Delete from the cursor to the start of the word
+  Delete one segment backward (JMESPath-aware).
+  Removes the last field/index/function one step at a time.
+  Inside &field) argument: deletes the field name but keeps '&'.
 
 CTRL-U
-  Delete whole query
+  Delete whole query.
+
+CTRL-X
+  Toggle function description display (visible when function candidates are shown).
 
 CTRL-F / Right Arrow
-  Move cursor a character to the right
+  Move cursor a character to the right.
 
 CTRL-B / Left Arrow
-  Move cursor a character to the left
+  Move cursor a character to the left.
 
 CTRL-A
-  To the first character of the 'Filter'
+  Move cursor to the first character of the Filter.
 
 CTRL-E
-  To the end of the 'Filter'
+  Move cursor to the end of the Filter.
 
 CTRL-J
-  Scroll json buffer 1 line downwards
+  Scroll json buffer 1 line downwards.
 
 CTRL-K
-  Scroll json buffer 1 line upwards
+  Scroll json buffer 1 line upwards.
 
 CTRL-G
-  Scroll json buffer to bottom
+  Scroll json buffer to bottom.
 
 CTRL-T
-  Scroll json buffer to top
+  Scroll json buffer to top.
 
 CTRL-N
-  Scroll json buffer 'Page Down'
+  Scroll json buffer Page Down.
 
 CTRL-P
-  Scroll json buffer 'Page Up'
+  Scroll json buffer Page Up.
 
 CTRL-L
-  Change view mode whole json or keys (only object)
+  Toggle view mode: full JSON or keys-only (objects only).
 
 ESC
-  Hide a candidate box
+  Hide the candidate list.
+
+Up Arrow
+  Navigate to the previous query in history.
+
+Down Arrow
+  Navigate to the next query in history.
+
+============ JMESPath examples =============
+
+.users[*].name             wildcard: extract name from every user
+. | keys(@)                pipe + function: list root keys
+.users | sort_by(@, &name) sort array of objects by field
+.users | length(@)         pipe + function: count elements
 
 `
 }

--- a/cmd/jid/jid.go
+++ b/cmd/jid/jid.go
@@ -8,7 +8,7 @@ import (
 	"github.com/simeji/jid"
 )
 
-const VERSION = "1.1.1"
+const VERSION = "1.1.2"
 
 func main() {
 	content := os.Stdin

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ header:
   actions:
     - label: "GitHub"
       url: "https://github.com/simeji/jid"
-    - label: "Download v1.1.1"
-      url: "https://github.com/simeji/jid/releases/tag/v1.1.1"
+    - label: "Download v1.1.2"
+      url: "https://github.com/simeji/jid/releases/tag/v1.1.2"
 excerpt: >
   Interactively drill down JSON in your terminal.
   JMESPath support, query history, key highlighting, and more.
@@ -138,5 +138,5 @@ scroll_up    = "ctrl+k"
 
 <div style="text-align:center; margin-top: 2em;">
   <a href="https://github.com/simeji/jid" class="btn btn--primary btn--large">View on GitHub</a>
-  <a href="https://github.com/simeji/jid/releases/tag/v1.1.1" class="btn btn--inverse btn--large">Download v1.1.1</a>
+  <a href="https://github.com/simeji/jid/releases/tag/v1.1.2" class="btn btn--inverse btn--large">Download v1.1.2</a>
 </div>

--- a/engine.go
+++ b/engine.go
@@ -327,6 +327,15 @@ func (e *Engine) setCandidateData() {
 	if isFuncCandidates || isJMESPathFieldCandidates {
 		// Auto-enter candidate mode so the list appears without a Tab press.
 		e.candidatemode = true
+		// When entering &field candidate mode, remove the placeholder text from the
+		// query string (e.g. "field" in "&field)") so the user sees just "&".
+		if isJMESPathFieldCandidates && strings.Contains(qs0, "&") && e.placeholderStart >= 0 && e.placeholderLen > 0 {
+			for i := 0; i < e.placeholderLen; i++ {
+				_ = e.query.Delete(e.placeholderStart)
+			}
+			e.queryCursorIdx = e.placeholderStart
+			e.clearPlaceholder()
+		}
 		if e.candidateidx >= l {
 			e.candidateidx = 0
 		}
@@ -371,7 +380,14 @@ func (e *Engine) confirmCandidate() {
 		qs := e.query.StringGet()
 		if pipeIdx := strings.LastIndex(qs, "|"); pipeIdx >= 0 {
 			suffix := strings.TrimLeft(qs[pipeIdx+1:], " ")
-			if strings.Contains(suffix, "(") {
+			if ampIdx := strings.LastIndex(suffix, "&"); ampIdx >= 0 && strings.Contains(suffix, "(") {
+				// &field typing inside function argument (e.g. "sort_by(@, &na)").
+				// Replace everything after the last "&" with the selected field name.
+				absAmpIdx := strings.LastIndex(qs, "&")
+				_ = e.query.StringSet(qs[:absAmpIdx+1] + selected + ")")
+				e.queryCursorIdx = e.query.Length()
+				e.clearPlaceholder()
+			} else if strings.Contains(suffix, "(") {
 				// The pipe suffix is a complete expression (e.g. "to_array(@)[0]").
 				// Append .field to the full query rather than stripping back to the base.
 				// If query already ends with "." don't add another.
@@ -458,9 +474,10 @@ func (e *Engine) toggleKeymode() {
 }
 // removeLastJMESPathSegment removes the last navigation segment from a
 // JMESPath expression suffix, working backwards:
-//   "to_array(@)[0].id"  → "to_array(@)[0]"  (remove .field)
-//   "to_array(@)[0]"     → "to_array(@)"      (remove [index])
-//   "to_array(@)"        → ""                 (remove function call)
+//   "to_array(@)[0].id"        → "to_array(@)[0]"  (remove .field)
+//   "to_array(@)[0]"           → "to_array(@)"      (remove [index])
+//   "to_array(@)"              → ""                 (remove function call)
+//   "max_by(@, &base_stat)"    → "max_by(@, "       (remove &field) argument)
 func removeLastJMESPathSegment(expr string) string {
 	if expr == "" {
 		return ""
@@ -483,6 +500,12 @@ func removeLastJMESPathSegment(expr string) string {
 		case '.':
 			if parenDepth == 0 && bracketDepth == 0 {
 				return expr[:i]
+			}
+		case '&':
+			// Inside a function call: "&field)" is one deletion unit; keep the "&".
+			// e.g. "max_by(@, &base_stat)" → "max_by(@, &"
+			if parenDepth > 0 && bracketDepth == 0 {
+				return expr[:i+1]
 			}
 		}
 	}
@@ -572,7 +595,7 @@ func (e *Engine) tabAction() {
 			return
 		}
 		e.candidateidx = (e.candidateidx + 1) % len(e.candidates)
-		e.queryCursorIdx = e.query.Length()
+		e.queryCursorIdx = e.ampFieldCursorPos(qs)
 		e.candidateScrollNeeded = true
 		return
 	}
@@ -631,12 +654,29 @@ func (e *Engine) shiftTabAction() {
 		} else {
 			e.candidateidx--
 		}
-		e.queryCursorIdx = e.query.Length()
+		e.queryCursorIdx = e.ampFieldCursorPos(e.query.StringGet())
 		e.candidateScrollNeeded = true
 		return
 	}
 	e.changeArrayIndex(-1)
 }
+// ampFieldCursorPos returns the cursor position to use while cycling candidates
+// in &partial mode. When the query contains "&" inside a function call (e.g.
+// "max_by(@, &)"), the cursor should sit right after "&" (between "&" and ")"),
+// not at the end of the query. Otherwise returns query.Length().
+func (e *Engine) ampFieldCursorPos(qs string) int {
+	if pipeIdx := strings.LastIndex(qs, "|"); pipeIdx >= 0 {
+		suffix := strings.TrimLeft(qs[pipeIdx+1:], " ")
+		if _, ok := ampFieldPartial(suffix); ok {
+			ampIdx := strings.LastIndex(qs, "&")
+			if ampIdx >= 0 {
+				return len([]rune(qs[:ampIdx+1]))
+			}
+		}
+	}
+	return e.query.Length()
+}
+
 func (e *Engine) setQuitRequested() {
 	e.quitRequested = true
 }

--- a/engine.go
+++ b/engine.go
@@ -380,9 +380,11 @@ func (e *Engine) confirmCandidate() {
 		qs := e.query.StringGet()
 		if pipeIdx := strings.LastIndex(qs, "|"); pipeIdx >= 0 {
 			suffix := strings.TrimLeft(qs[pipeIdx+1:], " ")
-			if ampIdx := strings.LastIndex(suffix, "&"); ampIdx >= 0 && strings.Contains(suffix, "(") {
-				// &field typing inside function argument (e.g. "sort_by(@, &na)").
+			if _, ok := ampFieldPartial(suffix); ok {
+				// Active &partial editing inside a function argument (e.g. "sort_by(@, &na)").
 				// Replace everything after the last "&" with the selected field name.
+				// Use ampFieldPartial to guard against matching an already-completed
+				// expression that happens to contain "&" (e.g. "max_by(@, &age).field").
 				absAmpIdx := strings.LastIndex(qs, "&")
 				_ = e.query.StringSet(qs[:absAmpIdx+1] + selected + ")")
 				e.queryCursorIdx = e.query.Length()
@@ -484,8 +486,25 @@ func removeLastJMESPathSegment(expr string) string {
 	}
 	parenDepth := 0
 	bracketDepth := 0
+	inString := false
+	stringChar := byte(0)
 	for i := len(expr) - 1; i >= 0; i-- {
-		switch expr[i] {
+		c := expr[i]
+		// Track string literal boundaries (scan right-to-left: opening quote = exit,
+		// closing quote = enter). Single quotes only — JMESPath uses '' for literals.
+		if c == '\'' || c == '"' {
+			if inString && c == stringChar {
+				inString = false
+			} else if !inString {
+				inString = true
+				stringChar = c
+			}
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch c {
 		case ')':
 			parenDepth++
 		case '(':
@@ -502,7 +521,8 @@ func removeLastJMESPathSegment(expr string) string {
 				return expr[:i]
 			}
 		case '&':
-			// Inside a function call: "&field)" is one deletion unit; keep the "&".
+			// Inside a function call (not inside a string literal):
+			// "&field)" is one deletion unit; keep the "&".
 			// e.g. "max_by(@, &base_stat)" → "max_by(@, &"
 			if parenDepth > 0 && bracketDepth == 0 {
 				return expr[:i+1]

--- a/engine_test.go
+++ b/engine_test.go
@@ -375,6 +375,8 @@ func TestRemoveLastJMESPathSegment(t *testing.T) {
 	assert.Equal("max_by(@, &", removeLastJMESPathSegment("max_by(@, &base_stat)"))
 	assert.Equal("sort_by(@, &", removeLastJMESPathSegment("sort_by(@, &name)"))
 	assert.Equal("sort_by(@, &", removeLastJMESPathSegment("sort_by(@, &)"))
+	// & inside a string literal must NOT trigger the &-stop rule
+	assert.Equal("", removeLastJMESPathSegment("contains(@, 'a&b')"))
 }
 
 func TestDeleteWordBackwardJMESPath(t *testing.T) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -371,8 +371,10 @@ func TestRemoveLastJMESPathSegment(t *testing.T) {
 	assert.Equal("", removeLastJMESPathSegment("foo"))
 	assert.Equal("foo", removeLastJMESPathSegment("foo[0]"))
 	assert.Equal("foo.bar[1]", removeLastJMESPathSegment("foo.bar[1].baz"))
-	// dots inside parens are not treated as separators
-	assert.Equal("", removeLastJMESPathSegment("sort_by(@, &name)"))
+	// &field) inside a function call is one deletion unit; & is kept
+	assert.Equal("max_by(@, &", removeLastJMESPathSegment("max_by(@, &base_stat)"))
+	assert.Equal("sort_by(@, &", removeLastJMESPathSegment("sort_by(@, &name)"))
+	assert.Equal("sort_by(@, &", removeLastJMESPathSegment("sort_by(@, &)"))
 }
 
 func TestDeleteWordBackwardJMESPath(t *testing.T) {
@@ -402,6 +404,12 @@ func TestDeleteWordBackwardJMESPath(t *testing.T) {
 
 	e.deleteWordBackward()
 	assert.Equal(".", e.query.StringGet())
+
+	// &field) argument deletion: & is preserved
+	e.query.StringSet(".stats | max_by(@, &base_stat)")
+	e.queryCursorIdx = e.query.Length()
+	e.deleteWordBackward()
+	assert.Equal(".stats | max_by(@, &", e.query.StringGet())
 }
 
 func TestConfirmCandidateJMESPath(t *testing.T) {
@@ -565,6 +573,65 @@ func TestFindKeyLineInContentsShallowWins(t *testing.T) {
 	line, indent := findKeyLineInContents(contents, "name")
 	assert.Equal(t, 6, line)   // root-level line
 	assert.Equal(t, 2, indent) // shallowest indent
+}
+
+func TestAmpFieldCursorPos(t *testing.T) {
+	e := getEngine(`[{"name":"alice","age":30}]`, "")
+
+	// &partial) mode: cursor should land right after &
+	e.query.StringSet(". | max_by(@, &)")
+	pos := e.ampFieldCursorPos(e.query.StringGet())
+	// ". | max_by(@, &" has 15 runes (& at index 14), so cursor = 15
+	assert.Equal(t, 15, pos)
+
+	// with partial typed: cursor stays right after & (index 15 as well)
+	e.query.StringSet(". | max_by(@, &base_stat)")
+	pos = e.ampFieldCursorPos(e.query.StringGet())
+	assert.Equal(t, 15, pos)
+
+	// no & in query: fall back to query.Length()
+	e.query.StringSet(". | keys(@)")
+	pos = e.ampFieldCursorPos(e.query.StringGet())
+	assert.Equal(t, e.query.Length(), pos)
+
+	// no pipe: fall back to query.Length()
+	e.query.StringSet(".name")
+	pos = e.ampFieldCursorPos(e.query.StringGet())
+	assert.Equal(t, e.query.Length(), pos)
+}
+
+// TestSetCandidateDataAmpFieldCursorPosition verifies that when &field placeholder
+// text is deleted from the query, the cursor is placed at placeholderStart (between
+// '&' and ')'), NOT at the end of the query string.
+func TestSetCandidateDataAmpFieldCursorPosition(t *testing.T) {
+	// JSON: array of objects, query has "&field)" placeholder inside a pipe expression
+	e := getEngine(`[{"name":"alice","age":30}]`, "")
+	// Simulate the state after sort_by(@, &field) was auto-inserted:
+	//   query = ". | sort_by(@, &field)"
+	//   placeholderStart = index of 'f' in "field" = 16 (". | sort_by(@, &" is 16 runes)
+	//   placeholderLen   = 5 ("field")
+	e.query.StringSet(". | sort_by(@, &field)")
+	// placeholderStart is the rune index of the first char of "field"
+	// ". | sort_by(@, &" has 17 chars (indices 0..16), so "field" starts at 17
+	phStart := len([]rune(". | sort_by(@, &"))
+	e.placeholderStart = phStart
+	e.placeholderLen = 5 // len("field")
+	e.queryCursorIdx = phStart
+
+	// Force the candidates that setCandidateData will see (simulates what
+	// getContents() would produce for this query)
+	e.candidates = []string{"age", "name"}
+	e.complete = []string{"", "age"}
+
+	e.setCandidateData()
+
+	// After deletion: query becomes ". | sort_by(@, &)" (field removed)
+	assert.Equal(t, ". | sort_by(@, &)", e.query.StringGet())
+	// Cursor should be at placeholderStart (between '&' and ')'), not at the end
+	assert.Equal(t, phStart, e.queryCursorIdx)
+	// Placeholder must be cleared
+	assert.Equal(t, -1, e.placeholderStart)
+	assert.Equal(t, 0, e.placeholderLen)
 }
 
 func getEngine(j string, qs string) *Engine {

--- a/json_manager.go
+++ b/json_manager.go
@@ -230,6 +230,59 @@ func isFunctionTypingMode(qs string) bool {
 	return !strings.Contains(suffix, "(")
 }
 
+// ampFieldCandidates returns the base result with field candidates for &partial completion.
+func (jm *JsonManager) ampFieldCandidates(baseExpr, partial string) (*simplejson.Json, []string, []string, error) {
+	var baseResult *simplejson.Json
+	if baseExpr == "@" {
+		baseResult = jm.origin
+	} else {
+		var berr error
+		baseResult, berr = jm.evalBaseExpr(baseExpr)
+		if berr != nil {
+			baseResult = jm.origin
+		}
+	}
+	// For array base, use first element's keys
+	el := baseResult
+	if arr, arrErr := baseResult.Array(); arrErr == nil && len(arr) > 0 {
+		el = baseResult.GetIndex(0)
+	}
+	fieldCandidates := jm.suggestion.GetCandidateKeys(el, partial)
+	// If no candidates match (e.g. partial is placeholder text like "field"),
+	// fall back to showing all keys.
+	if len(fieldCandidates) == 0 {
+		fieldCandidates = jm.suggestion.GetCandidateKeys(el, "")
+	}
+	// Don't emit a green inline hint: the cursor sits inside "&partial)" so any
+	// suffix hint would appear after ")" and confuse the display. The candidate
+	// list already shows all options.
+	return baseResult, []string{"", ""}, fieldCandidates, nil
+}
+
+// ampFieldPartial detects when the user is typing a field name after `&` inside
+// a function argument (e.g. "sort_by(@, &na" → partial="na", ok=true).
+// Returns the partial identifier and true if the pattern is detected.
+func ampFieldPartial(suffix string) (string, bool) {
+	parenIdx := strings.Index(suffix, "(")
+	if parenIdx < 0 {
+		return "", false
+	}
+	ampIdx := strings.LastIndex(suffix, "&")
+	if ampIdx < 0 || ampIdx < parenIdx {
+		return "", false
+	}
+	partial := suffix[ampIdx+1:]
+	// Strip trailing ) which may be present when the function template is already inserted
+	partial = strings.TrimRight(partial, ")")
+	// partial must contain only identifier characters (letters, digits, underscore)
+	for _, ch := range partial {
+		if ch != '_' && !('a' <= ch && ch <= 'z') && !('A' <= ch && ch <= 'Z') && !('0' <= ch && ch <= '9') {
+			return "", false
+		}
+	}
+	return partial, true
+}
+
 // getFilteredDataJMESPath handles queries that contain JMESPath-specific syntax.
 func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simplejson.Json, []string, []string, error) {
 	expr := jmespathExprFromQuery(qs)
@@ -337,6 +390,16 @@ func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simple
 			suggest := jm.suggestion.Get(result, "")
 			return result, suggest, []string{}, nil
 		}
+		// Null result: may be &partial with a non-existent field (e.g. max_by(@, &field)).
+		// Detect &partial pattern and show field candidates instead.
+		if result.Interface() == nil {
+			if baseExpr2, hasPipe2 := baseExprBeforePipe(qs); hasPipe2 {
+				suffix2 := pipeSuffix(qs)
+				if partial, ok := ampFieldPartial(suffix2); ok {
+					return jm.ampFieldCandidates(baseExpr2, partial)
+				}
+			}
+		}
 		// Map (object) result: suggest field keys so the user can keep digging.
 		if candidateKeys := getCurrentKeys(result); len(candidateKeys) > 0 {
 			fieldSuggest := jm.suggestion.Get(result, "")
@@ -381,6 +444,11 @@ func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simple
 				baseResult = jm.origin
 			}
 		}
+		// Detect &partial pattern in function argument (e.g. "sort_by(@, &ba").
+		if partial, ok := ampFieldPartial(suffix); ok {
+			return jm.ampFieldCandidates(baseExpr, partial)
+		}
+
 		// Provide function-name candidates matching the typed suffix.
 		baseType := jm.suggestion.GetCurrentType(baseResult)
 		fnCandidates := jm.suggestion.GetFunctionCandidatesFiltered(suffix, baseType)

--- a/json_manager.go
+++ b/json_manager.go
@@ -392,7 +392,9 @@ func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simple
 		}
 		// Null result: may be &partial with a non-existent field (e.g. max_by(@, &field)).
 		// Detect &partial pattern and show field candidates instead.
-		if result.Interface() == nil {
+		// Skip this fallback when confirm=true so that a confirmed expression that
+		// genuinely returns null (e.g. max_by(@, &missing)) produces null output.
+		if result.Interface() == nil && !confirm {
 			if baseExpr2, hasPipe2 := baseExprBeforePipe(qs); hasPipe2 {
 				suffix2 := pipeSuffix(qs)
 				if partial, ok := ampFieldPartial(suffix2); ok {
@@ -408,7 +410,14 @@ func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simple
 		return result, []string{"", ""}, []string{}, nil
 	}
 
-	// Expression is incomplete (parse error). Check whether the user is typing after a pipe.
+	// Expression is incomplete (parse error).
+	// When confirming (user pressed Enter), do not fall back to base-result recovery;
+	// return the error so the caller can display it correctly.
+	if confirm {
+		return jm.origin, []string{"", ""}, []string{}, err
+	}
+
+	// Check whether the user is typing after a pipe.
 	baseExpr, hasPipe := baseExprBeforePipe(qs)
 	suffix := pipeSuffix(qs)
 
@@ -445,8 +454,11 @@ func (jm *JsonManager) getFilteredDataJMESPath(qs string, confirm bool) (*simple
 			}
 		}
 		// Detect &partial pattern in function argument (e.g. "sort_by(@, &ba").
-		if partial, ok := ampFieldPartial(suffix); ok {
-			return jm.ampFieldCandidates(baseExpr, partial)
+		// Skip when confirm=true so that a confirmed query returns its actual result.
+		if !confirm {
+			if partial, ok := ampFieldPartial(suffix); ok {
+				return jm.ampFieldCandidates(baseExpr, partial)
+			}
 		}
 
 		// Provide function-name candidates matching the typed suffix.

--- a/json_manager_test.go
+++ b/json_manager_test.go
@@ -741,6 +741,12 @@ func TestGetFilteredDataJMESPathAmpField(t *testing.T) {
 	assert.Nil(err)
 	d, _ := result.Encode()
 	assert.Contains(string(d), "alice") // age 30 → max
+
+	// confirm=true with a missing field → JMESPath returns an error (cannot compare
+	// null values), NOT the base array that the suggestion fallback would return.
+	q = NewQueryWithString(". | max_by(@, &missing)")
+	_, _, _, err = jm.GetFilteredData(q, true)
+	assert.NotNil(err, "confirm=true should propagate the JMESPath error, not silently return base array")
 }
 
 func TestIsEmptyJson(t *testing.T) {

--- a/json_manager_test.go
+++ b/json_manager_test.go
@@ -651,6 +651,98 @@ func TestGetFilteredDataJMESPathObjectResult(t *testing.T) {
 	assert.Contains(candidates, "id")
 }
 
+func TestAmpFieldPartial(t *testing.T) {
+	// basic: "&field)" inside function call
+	partial, ok := ampFieldPartial("sort_by(@, &field)")
+	assert.True(t, ok)
+	assert.Equal(t, "field", partial)
+
+	// partial identifier, no closing paren
+	partial, ok = ampFieldPartial("sort_by(@, &na")
+	assert.True(t, ok)
+	assert.Equal(t, "na", partial)
+
+	// empty partial (just "&)")
+	partial, ok = ampFieldPartial("max_by(@, &)")
+	assert.True(t, ok)
+	assert.Equal(t, "", partial)
+
+	// empty partial (just "&" with no closing paren)
+	partial, ok = ampFieldPartial("max_by(@, &")
+	assert.True(t, ok)
+	assert.Equal(t, "", partial)
+
+	// no "(" → not in function call
+	_, ok = ampFieldPartial("&field")
+	assert.False(t, ok)
+
+	// "&" before "(" → not after open-paren
+	_, ok = ampFieldPartial("&max_by(@, field)")
+	assert.False(t, ok)
+
+	// no "&" at all
+	_, ok = ampFieldPartial("sort_by(@, name)")
+	assert.False(t, ok)
+
+	// identifier with underscore and digits
+	partial, ok = ampFieldPartial("sort_by(@, &base_stat2)")
+	assert.True(t, ok)
+	assert.Equal(t, "base_stat2", partial)
+}
+
+func TestAmpFieldCandidates(t *testing.T) {
+	data := `[{"name":"alice","age":30},{"name":"bob","age":25}]`
+	r := bytes.NewBufferString(data)
+	jm, _ := NewJsonManager(r)
+
+	// empty partial → all keys; no inline hint (["",""])
+	_, suggest, candidates, err := jm.ampFieldCandidates("@", "")
+	assert.Nil(t, err)
+	assert.Contains(t, candidates, "name")
+	assert.Contains(t, candidates, "age")
+	assert.Equal(t, []string{"", ""}, suggest)
+
+	// partial "na" → only "name"; still no inline hint
+	_, suggest, candidates, err = jm.ampFieldCandidates("@", "na")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"name"}, candidates)
+	assert.Equal(t, []string{"", ""}, suggest)
+
+	// placeholder text "field" → no match → fall back to all keys; no inline hint
+	_, suggest, candidates, err = jm.ampFieldCandidates("@", "field")
+	assert.Nil(t, err)
+	assert.Contains(t, candidates, "name")
+	assert.Contains(t, candidates, "age")
+	assert.Equal(t, []string{"", ""}, suggest)
+}
+
+func TestGetFilteredDataJMESPathAmpField(t *testing.T) {
+	assert := assert.New(t)
+	data := `[{"name":"alice","age":30},{"name":"bob","age":25}]`
+	r := bytes.NewBufferString(data)
+	jm, _ := NewJsonManager(r)
+
+	// "&field)" placeholder → all field candidates from array elements
+	q := NewQueryWithString(". | max_by(@, &field)")
+	_, _, candidates, err := jm.GetFilteredData(q, false)
+	assert.Nil(err)
+	assert.Contains(candidates, "name")
+	assert.Contains(candidates, "age")
+
+	// "&na" partial (no closing paren) → "name" candidate
+	q = NewQueryWithString(". | max_by(@, &na")
+	_, _, candidates, err = jm.GetFilteredData(q, false)
+	assert.Nil(err)
+	assert.Contains(candidates, "name")
+
+	// confirmed expression → evaluates normally, no amp-field candidates
+	q = NewQueryWithString(". | max_by(@, &age)")
+	result, _, _, err := jm.GetFilteredData(q, true)
+	assert.Nil(err)
+	d, _ := result.Encode()
+	assert.Contains(string(d), "alice") // age 30 → max
+}
+
 func TestIsEmptyJson(t *testing.T) {
 	var assert = assert.New(t)
 	r := bytes.NewBufferString(`{"name":"go"}`)

--- a/terminal.go
+++ b/terminal.go
@@ -130,7 +130,7 @@ func (t *Terminal) drawFilterLine(qs string, complete string, phStart int, phLen
 			c = termbox.ColorGreen
 		}
 		if phByteStart >= 0 && i >= phByteStart && i < phByteEnd {
-			c = termbox.ColorBlue
+			c = termbox.ColorCyan
 		}
 		cells = append(cells, termbox.Cell{
 			Ch: s,


### PR DESCRIPTION
## Summary

- When a function template inserts a `&field` placeholder (e.g. `sort_by(@, &field)`), field candidates from the base array are automatically shown for Tab-cycling or partial typing
- Placeholder text is removed immediately on entering candidate mode; cursor is placed between `&` and `)` for clean inline editing
- `Ctrl+W` treats `&field)` as one deletion unit and stops at `&`, preserving it (e.g. `max_by(@, &base_stat)` → `max_by(@, &`)
- Suppressed misleading green completion hint in `&partial` mode (hint was appearing after `)`)
- Cursor stays between `&` and `)` while Tab-cycling field candidates

## Changes

- `json_manager.go`: Add `ampFieldPartial` (detects `&partial` pattern) and `ampFieldCandidates` (returns field candidates from base array); suppress inline hint in `&partial` mode
- `engine.go`: Fix placeholder deletion cursor position (`placeholderStart` instead of `query.Length()`); add `ampFieldCursorPos` helper for Tab/Shift+Tab; extend `removeLastJMESPathSegment` to treat `&field)` as a unit and preserve `&`
- `terminal.go`: Change placeholder color from `ColorBlue` to `ColorCyan` (lighter)
- `engine_test.go`, `json_manager_test.go`: Tests for `ampFieldPartial`, `ampFieldCandidates`, cursor position after placeholder deletion, `ampFieldCursorPos`, `removeLastJMESPathSegment` with `&field`, and `deleteWordBackward` with `&field`
- `ChangeLog`, `README.md`, `cmd/jid/jid.go`: Document new behavior and update CLI help

## Test plan

- [x] `go test ./...` passes
- [ ] Manual: type `.stats | sort_by(@, &` → field candidates appear; Tab cycles; selection inserts correctly
- [ ] Manual: `Ctrl+W` on `max_by(@, &base_stat)` → `max_by(@, &`
- [ ] Manual: typing partial after `&` filters candidates correctly

@codex review