### PR TITLE
Bump version to 1.1.3 (patch release)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ChangeLog
 =======
 
-### 1.2.0 - Aug 1 2026
+### 1.1.3 - Aug 1 2026
 
 Performance:
 * Precompiled all hot-path regexes (query validation, keyword parsing, JMESPath

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,20 @@
 ChangeLog
 =======
 
+### 1.2.0 - Aug 1 2026
+
+Performance:
+* Precompiled all hot-path regexes (query validation, keyword parsing, JMESPath
+  detection, suggestion matching) that were previously recompiled on every keystroke
+* Memoized `GetFilteredData`/`GetPretty` and JMESPath expression evaluation so
+  repeated frames (scrolling, candidate cycling, cursor moves) with an unchanged
+  query skip re-filtering and re-marshaling entirely
+* Cached formatted terminal cells across unchanged frames, avoiding a full
+  re-colorization pass of the document on every redraw
+* Reduced allocations in suggestion key generation, cell rendering, and candidate
+  key highlighting
+* Key mode (`Ctrl+L`) no longer pretty-prints the filtered JSON it doesn't display
+
 ### 1.1.2 - Apr 12 2026
 
 Features:

--- a/cmd/jid/jid.go
+++ b/cmd/jid/jid.go
@@ -8,7 +8,7 @@ import (
 	"github.com/simeji/jid"
 )
 
-const VERSION = "1.2.0"
+const VERSION = "1.1.3"
 
 func main() {
 	content := os.Stdin

--- a/cmd/jid/jid.go
+++ b/cmd/jid/jid.go
@@ -8,7 +8,7 @@ import (
 	"github.com/simeji/jid"
 )
 
-const VERSION = "1.1.2"
+const VERSION = "1.2.0"
 
 func main() {
 	content := os.Stdin

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ header:
   actions:
     - label: "GitHub"
       url: "https://github.com/simeji/jid"
-    - label: "Download v1.1.2"
-      url: "https://github.com/simeji/jid/releases/tag/v1.1.2"
+    - label: "Download v1.2.0"
+      url: "https://github.com/simeji/jid/releases/tag/v1.2.0"
 excerpt: >
   Interactively drill down JSON in your terminal.
   JMESPath support, query history, key highlighting, and more.
@@ -138,5 +138,5 @@ scroll_up    = "ctrl+k"
 
 <div style="text-align:center; margin-top: 2em;">
   <a href="https://github.com/simeji/jid" class="btn btn--primary btn--large">View on GitHub</a>
-  <a href="https://github.com/simeji/jid/releases/tag/v1.1.2" class="btn btn--inverse btn--large">Download v1.1.2</a>
+  <a href="https://github.com/simeji/jid/releases/tag/v1.2.0" class="btn btn--inverse btn--large">Download v1.2.0</a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ header:
   actions:
     - label: "GitHub"
       url: "https://github.com/simeji/jid"
-    - label: "Download v1.2.0"
-      url: "https://github.com/simeji/jid/releases/tag/v1.2.0"
+    - label: "Download v1.1.3"
+      url: "https://github.com/simeji/jid/releases/tag/v1.1.3"
 excerpt: >
   Interactively drill down JSON in your terminal.
   JMESPath support, query history, key highlighting, and more.
@@ -138,5 +138,5 @@ scroll_up    = "ctrl+k"
 
 <div style="text-align:center; margin-top: 2em;">
   <a href="https://github.com/simeji/jid" class="btn btn--primary btn--large">View on GitHub</a>
-  <a href="https://github.com/simeji/jid/releases/tag/v1.2.0" class="btn btn--inverse btn--large">Download v1.2.0</a>
+  <a href="https://github.com/simeji/jid/releases/tag/v1.1.3" class="btn btn--inverse btn--large">Download v1.1.3</a>
 </div>


### PR DESCRIPTION
## Summary

- Bumps `VERSION` in `cmd/jid/jid.go` from 1.1.2 to 1.2.0 (minor release), following the perf work merged in #115.
- Adds a `1.2.0` entry to `ChangeLog` summarizing the performance improvements: precompiled hot-path regexes, `GetFilteredData`/`GetPretty`/`evalJMESPath` memoization, cached terminal cell rendering, reduced allocations, and skipping the pretty marshal in key mode.
- Updates the download links in `docs/index.md` from v1.1.2 to v1.2.0, following the existing convention from prior version bumps (e.g. 849faf6).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all existing tests pass)
- [x] `jid --version` prints `jid version v1.2.0`

Note: per repo convention, no git tag / GitHub release is created here — that step is done separately when explicitly requested.

@codex review